### PR TITLE
(DOCSP-20213) Remove Old Product Name

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,4 +1,4 @@
-define: prefix mongodb-visual-studio/
+define: prefix mongodb-analyzer/
 define: base https://docs.mongodb.com/${prefix}
 define: versions main
 

--- a/snooty.toml
+++ b/snooty.toml
@@ -1,5 +1,5 @@
 name = "visual-studio-extension"
-title = "Visual Studio Extension"
+title = "MongoDB Analyzer"
 
 [constants]
 product = "MongoDB Analyzer"


### PR DESCRIPTION
## Pull Request Info

Remove all mention of "Visual Studio Extension" from perspective of readers and from the `/source` directory.

This DOES NOT include the task of renaming the repository or updating the `docs-worker-pool` repo.

### Issue JIRA link:

https://jira.mongodb.org/browse/DOCSP-20213

### Snooty build log:

**Paste your workerpool job link here**

### Docs staging link (requires sign-in on MongoDB Corp SSO):

https://docs-mongodbcom-staging.corp.mongodb.com/visual-studio-extension/docsworker-xlarge/DOCSP-20213-Remove-Old-Product-Name/

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
