### PR TITLE
Typo in Redirect

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,4 +1,4 @@
-define: prefix mongodb-analyzer/
+define: prefix mongodb-analyzer
 define: base https://docs.mongodb.com/${prefix}
 define: versions main
 


### PR DESCRIPTION
## Pull Request Info

Remove extra slash in prefix in redirect file. Redirects https://docs.mongodb.com/mongodb-analyzer to https://docs.mongodb.com/mongodb-analyzer//current

### Issue JIRA link:

No ticket

### Snooty build log:

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=61d8859041accb3633bee552

### Docs staging link (requires sign-in on MongoDB Corp SSO):

[Nothing to see in staging but here is the link](https://docs-mongodborg-staging.corp.mongodb.com/visual-studio-extension/docsworker-xlarge/fix-redirect-typo/)

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [ ] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
