### PR TITLE
Update base URL in redirects to www.

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,5 +1,5 @@
 define: prefix mongodb-analyzer
-define: base https://docs.mongodb.com/${prefix}
+define: base https://www.mongodb.com/docs/${prefix}
 define: versions v1.0 master
 
 raw: ${prefix}/ -> ${base}/current/


### PR DESCRIPTION
@terakilobyte Just what it says on the tin. We need to do this so that the redirects will work as expected once we move to www.mongodb.com/docs