### PR TITLE
subdomain: add docs/ to S3 keys

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,4 +1,4 @@
-define: prefix mongodb-analyzer
+define: prefix docs/mongodb-analyzer
 define: base https://www.mongodb.com/docs/${prefix}
 define: versions v1.0 master
 


### PR DESCRIPTION
@terakilobyte We're building everything to bucket/docs/projectname so we need to add the docs/ to the S3 keys as well. Sorry for the bonus PR.