### PR TITLE
remove v1.1 feature from v1.0 docs

### DIFF
--- a/source/code-type/builders.txt
+++ b/source/code-type/builders.txt
@@ -85,29 +85,4 @@ information message displayed:
       .. figure:: /includes/images/builder-popup-photoshop.png
          :alt: Screenshot of builder expression in visual studio with information message displayed.
 
-Track Builder Variables
-~~~~~~~~~~~~~~~~~~~~~~~
-
-The {+product+} supports builder variable tracking and composition. You can
-combine multiple builder expressions with `logical operators
-<https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/boolean-logical-operators>`__
-and view the {+query-api+} translation in the information message.
-
-Click the following tabs to see a composed builder variable with and without an
-information message displayed:
-
-.. tabs::
-
-   .. tab:: Without Information Message
-      :tabid: no-message-variable
-
-      .. figure:: /includes/images/builder-variable.png
-         :alt: Screenshot of builder expression variable in visual studio with ellipsis annotation.
-
-   .. tab:: With Information Message
-      :tabid: message-variable
-
-      .. figure:: /includes/images/builder-variable-popup.png
-         :alt: Screenshot of builder expression variable in visual studio with information message displayed.
-
 .. include:: /includes/error-list-window.rst


### PR DESCRIPTION
removing track variables feature that was accidentally back-ported to v1.0 docs.

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/visual-studio-extension/docsworker-xlarge/v1.0/code-type/builders/#simple-builder-expressions (track variables section is no longer on the page)