### PR TITLE
Add redirects for not yet existing rules page

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -4,3 +4,7 @@ define: versions v1.0 v1.1 v1.2 master
 
 raw: ${prefix}/ -> ${base}/current/
 raw: ${prefix}/master -> ${base}/upcoming/
+
+# Redirects for Analyzer Rules
+[*-master]: ${prefix}/{version}/rules/ -> ${base}/${version}/
+[*-master]: ${prefix}/{version}/rules/* -> ${base}/${version}/

--- a/config/redirects
+++ b/config/redirects
@@ -7,4 +7,3 @@ raw: ${prefix}/master -> ${base}/upcoming/
 
 # Redirects for Analyzer Rules
 [*-master]: ${prefix}/{version}/rules/ -> ${base}/${version}/
-[*-master]: ${prefix}/{version}/rules/* -> ${base}/${version}/


### PR DESCRIPTION
# Pull Request Info
Adding redirects for a not-yet-existing "Rules" page to enable C# engineers to deploy a nuget package without broken links. There is a ticket to create the Rules page, which will include removing these redirects.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-visual-studio-extension/blob/master/REVIEWING.md)

JIRA - N/A
Staging - N/A

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
