### PR TITLE
Redirect typo

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -6,4 +6,4 @@ raw: ${prefix}/ -> ${base}/current/
 raw: ${prefix}/master -> ${base}/upcoming/
 
 # Redirects for Analyzer Rules
-[*-master]: ${prefix}/{version}/rules/ -> ${base}/${version}/
+[*-master]: ${prefix}/${version}/rules/ -> ${base}/${version}/


### PR DESCRIPTION
MUT Redirects output:

Redirect 301 /docs/mongodb-analyzer/ https://www.mongodb.com/docs/mongodb-analyzer/current/
Redirect 301 /docs/mongodb-analyzer/master https://www.mongodb.com/docs/mongodb-analyzer/upcoming/
Redirect 301 /docs/mongodb-analyzer/v1.0/rules/ https://www.mongodb.com/docs/mongodb-analyzer/v1.0/
Redirect 301 /docs/mongodb-analyzer/v1.1/rules/ https://www.mongodb.com/docs/mongodb-analyzer/v1.1/
Redirect 301 /docs/mongodb-analyzer/v1.2/rules/ https://www.mongodb.com/docs/mongodb-analyzer/v1.2/
Redirect 301 /docs/mongodb-analyzer/master/rules/ https://www.mongodb.com/docs/mongodb-analyzer/master/

[PR Reviewing Guidelines](https://github.com/mongodb/docs-visual-studio-extension/blob/master/REVIEWING.md)

JIRA - N/A
Staging -N/A

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
