### PR TITLE
Add missing meta descriptions

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -6,6 +6,9 @@
 {+product+}
 ===============================
 
+.. meta::
+   :description: Explore how the C# Analyzer helps translate MongoDB .NET/C# driver code into the MongoDB Query API and checks for unsupported expressions.
+
 .. toctree::
    :titlesonly:
    :maxdepth: 1


### PR DESCRIPTION
Adds missing meta descriptions generated by the Education AI Team\n\nSOURCE: https://docs.google.com/spreadsheets/d/1fdrjF4Ms9fMl96zLiLGsYD_V38rTfPLuKs5VQk4vz6E/edit?gid=1166644539